### PR TITLE
Evitar error al procesar Traslados Exentos

### DIFF
--- a/main.py
+++ b/main.py
@@ -255,6 +255,8 @@ class MainApplication(Frame):
                 isr = 0.0
                 ieps = 0.0
                 for t in root.findall('cfdi:Impuestos/cfdi:Traslados/cfdi:Traslado', namespaces=nsmap):
+                    if t.get('TipoFactor') == 'Exento':
+                        continue
                     if t.get('Impuesto') == '002':
                         iva += float(t.get('Importe'))
                     if t.get('Impuesto') == '001':


### PR DESCRIPTION
Resuelve el error "float() argument must be a string or a real number, not 'NoneType'" que ocurría al procesar los archivos XML de CFDI cuando existe un traslado de IVA (Impuesto="002") con el atributo TipoFactor="Exento". En estos casos, el atributo Importe no está presente, por lo que no debe intentarse convertir a float.

Soluciona el issue #1